### PR TITLE
JDA 5.0.0-beta.3 Update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     // https://mvnrepository.com/artifact/net.dv8tion/JDA
-    compileOnly("net.dv8tion:JDA:5.0.0-alpha.9")
+    compileOnly("net.dv8tion:JDA:5.0.0-beta.3")
 
     // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1")

--- a/src/main/kotlin/dev/ruffrick/jda/kotlinx/Events.kt
+++ b/src/main/kotlin/dev/ruffrick/jda/kotlinx/Events.kt
@@ -4,7 +4,7 @@ import dev.ruffrick.jda.kotlinx.event.SuspendEventListener
 import kotlinx.coroutines.delay
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Message
-import net.dv8tion.jda.api.entities.MessageChannel
+import net.dv8tion.jda.api.entities.channel.Channel
 import net.dv8tion.jda.api.events.GenericEvent
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent
@@ -84,7 +84,7 @@ suspend inline fun <reified T : GenericEvent> JDA.await(
     }
 }
 
-suspend inline fun MessageChannel.awaitMessage(
+suspend inline fun Channel.awaitMessage(
     crossinline predicate: MessageReceivedEvent.() -> Boolean = { true },
     limit: Int = 1,
     timeout: Long = 30_000,

--- a/src/main/kotlin/dev/ruffrick/jda/kotlinx/Events.kt
+++ b/src/main/kotlin/dev/ruffrick/jda/kotlinx/Events.kt
@@ -4,7 +4,7 @@ import dev.ruffrick.jda.kotlinx.event.SuspendEventListener
 import kotlinx.coroutines.delay
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Message
-import net.dv8tion.jda.api.entities.channel.Channel
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.events.GenericEvent
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent
@@ -84,7 +84,7 @@ suspend inline fun <reified T : GenericEvent> JDA.await(
     }
 }
 
-suspend inline fun Channel.awaitMessage(
+suspend inline fun MessageChannel.awaitMessage(
     crossinline predicate: MessageReceivedEvent.() -> Boolean = { true },
     limit: Int = 1,
     timeout: Long = 30_000,


### PR DESCRIPTION
# Overview
Updates JDA to `5.0.0-beta.3` and fixes the location of the `MessageChannel` import.